### PR TITLE
Proposal to explicitly use the moduleName as area for MVC routing

### DIFF
--- a/DNN Platform/DotNetNuke.Web.MvcPipeline/HtmlHelpers.cs
+++ b/DNN Platform/DotNetNuke.Web.MvcPipeline/HtmlHelpers.cs
@@ -17,7 +17,6 @@ namespace DotNetNuke.Web.MvcPipeline
     using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Modules;
 
-    // using DotNetNuke.Framework.Models;
     using DotNetNuke.Collections;
     using DotNetNuke.Web.MvcPipeline.Framework;
     using DotNetNuke.Web.MvcPipeline.Models;
@@ -58,7 +57,7 @@ namespace DotNetNuke.Web.MvcPipeline
             string actionName = string.Empty;
             try
             {
-                var area = Path.GetFileName(module.DesktopModule.FolderName);
+                var area = module.DesktopModule.FolderName;
                 if (controlSrc.EndsWith(".mvc", System.StringComparison.OrdinalIgnoreCase))
                 {
                     var controlKey = module.ModuleControl.ControlKey;
@@ -79,11 +78,9 @@ namespace DotNetNuke.Web.MvcPipeline
                         { "PanaName", module.PaneName },
                         { "ContainerSrc", module.ContainerSrc },
                         { "ContainerPath", module.ContainerPath },
-                        { "IconFile", module.IconFile }
+                        { "IconFile", module.IconFile },
+                        { "area", area }
                     };
-                    
-                    // controllerName = area + controllerName;
-                    values.Add("area", area);
 
                     var queryString = htmlHelper.ViewContext.HttpContext.Request.QueryString;
 

--- a/DNN Platform/DotNetNuke.Web.MvcPipeline/Routing/IMapRoute.cs
+++ b/DNN Platform/DotNetNuke.Web.MvcPipeline/Routing/IMapRoute.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Web.MvcPipeline.Routing
         /// <param name="namespaces">The namespace(s) in which to search for the controllers for this route.</param>
         /// <returns>A list of all routes that were registered.</returns>
         /// <remarks>The combination of moduleFolderName and routeName must be unique for each route.</remarks>
-        Route MapRoute(string moduleFolderName, string routeName, string url, string[] namespaces);
+        Route MapRoute(string moduleName, string moduleFolderName, string routeName, string url, string[] namespaces);
 
         /// <summary>Sets up the route(s) for DotNetNuke MVC Controls.</summary>
         /// <param name="moduleFolderName">The name of the folder under DesktopModules in which your module resides.</param>
@@ -27,7 +27,7 @@ namespace DotNetNuke.Web.MvcPipeline.Routing
         /// <param name="namespaces">The namespace(s) in which to search for the controllers for this route.</param>
         /// <returns>A list of all routes that were registered.</returns>
         /// <remarks>The combination of moduleFolderName and routeName must be unique for each route.</remarks>
-        Route MapRoute(string moduleFolderName, string routeName, string url, object defaults, string[] namespaces);
+        Route MapRoute(string moduleName, string moduleFolderName, string routeName, string url, object defaults, string[] namespaces);
 
         /// <summary>Sets up the route(s) for DotNetNuke MVC Controls.</summary>
         /// <param name="moduleFolderName">The name of the folder under DesktopModules in which your module resides.</param>
@@ -38,6 +38,6 @@ namespace DotNetNuke.Web.MvcPipeline.Routing
         /// <param name="namespaces">The namespace(s) in which to search for the controllers for this route.</param>
         /// <returns>A list of all routes that were registered.</returns>
         /// <remarks>The combination of moduleFolderName and routeName must be unique for each route.</remarks>
-        Route MapRoute(string moduleFolderName, string routeName, string url, object defaults, object constraints, string[] namespaces);
+        Route MapRoute(string moduleName, string moduleFolderName, string routeName, string url, object defaults, object constraints, string[] namespaces);
     }
 }

--- a/DNN Platform/DotNetNuke.Web.MvcPipeline/Routing/MvcRoutingManager.cs
+++ b/DNN Platform/DotNetNuke.Web.MvcPipeline/Routing/MvcRoutingManager.cs
@@ -38,19 +38,19 @@ namespace DotNetNuke.Web.MvcPipeline.Routing
 
         internal ITypeLocator TypeLocator { get; set; }
 
-        public Route MapRoute(string moduleFolderName, string routeName, string url, string[] namespaces)
+        public Route MapRoute(string moduleName, string moduleFolderName, string routeName, string url, string[] namespaces)
         {
-            return this.MapRoute(moduleFolderName, routeName, url, null /* defaults */, null /* constraints */, namespaces);
+            return this.MapRoute(moduleName, moduleFolderName, routeName, url, null /* defaults */, null /* constraints */, namespaces);
         }
 
         /// <inheritdoc/>
-        public Route MapRoute(string moduleFolderName, string routeName, string url, object defaults, string[] namespaces)
+        public Route MapRoute(string moduleName, string moduleFolderName, string routeName, string url, object defaults, string[] namespaces)
         {
-            return this.MapRoute(moduleFolderName, routeName, url, defaults, null /* constraints */, namespaces);
+            return this.MapRoute(moduleName, moduleFolderName, routeName, url, defaults, null /* constraints */, namespaces);
         }
 
         /// <inheritdoc/>
-        public Route MapRoute(string moduleFolderName, string routeName, string url, object defaults, object constraints, string[] namespaces)
+        public Route MapRoute(string moduleName, string moduleFolderName, string routeName, string url, object defaults, object constraints, string[] namespaces)
         {
             if (namespaces == null || namespaces.Length == 0 || string.IsNullOrEmpty(namespaces[0]))
             {
@@ -60,6 +60,7 @@ namespace DotNetNuke.Web.MvcPipeline.Routing
                     "namespaces"));
             }
 
+            Requires.NotNullOrEmpty("moduleName", moduleName);
             Requires.NotNullOrEmpty("moduleFolderName", moduleFolderName);
 
             url = url.Trim('/', '\\');
@@ -76,9 +77,9 @@ namespace DotNetNuke.Web.MvcPipeline.Routing
             {
                 var fullRouteName = this.portalAliasMvcRouteManager.GetRouteName(moduleFolderName, routeName, count);
                 var routeUrl = this.portalAliasMvcRouteManager.GetRouteUrl(moduleFolderName, url, count);
-                route = MapRouteWithNamespace(fullRouteName, moduleFolderName, routeUrl, defaults, constraints, namespaces);
+                route = MapRouteWithNamespace(fullRouteName, moduleName, routeUrl, defaults, constraints, namespaces);
                 this.routes.Add(route);
-                Logger.Trace("Mapping route: " + fullRouteName + " Area="+moduleFolderName + " @ " + routeUrl);
+                Logger.Trace("Mapping route: " + fullRouteName + " Area=" + moduleName + " @ " + routeUrl);
             }
 
             return route;

--- a/DNN Platform/Modules/HTML/Mvc/RouteConfig.cs
+++ b/DNN Platform/Modules/HTML/Mvc/RouteConfig.cs
@@ -4,12 +4,6 @@
 
 namespace DotNetNuke.Modules.Html.Mvc
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Web;
-
     using DotNetNuke.Web.MvcPipeline.Routing;
 
     public class RouteConfig : IMvcRouteMapper
@@ -17,6 +11,7 @@ namespace DotNetNuke.Modules.Html.Mvc
         public void RegisterRoutes(IMapRoute mapRouteManager)
         {
             mapRouteManager.MapRoute(
+                "DNN_HTML",
                 "HTML",
                 "Html",
                 "{controller}/{action}",


### PR DESCRIPTION
I feel the module foldername is not a good candidate for a unique key to identify it as "area" as you can get confusion over windows vs unix paths separators. The modulename is IMHO a better candidate.